### PR TITLE
Add back the original Keccak submission to SHA-3,

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@
   (Closes: #1646)
 - AES-NI: align key_schedule on a 16 byte boundary (Etienne Millon)
   (Closes: #1709)
+- Add original Keccak submission to SHA-3 (Yoichi Hirai)
 
 Release 1.11:
 - Adapt to "safe string" mode (OCaml 4.02 and later required).

--- a/README.txt
+++ b/README.txt
@@ -11,7 +11,7 @@ primitives provided include:
 - Symmetric-key ciphers: AES, DES, Triple-DES, ARCfour,
   in ECB, CBC, CFB, OFB and counter modes.
 - Public-key cryptography: RSA encryption, Diffie-Hellman key agreement. -
-Hash functions and MACs: SHA-1, SHA-2, SHA-3, RIPEMD160, MD5,
+Hash functions and MACs: SHA-1, SHA-2, SHA-3, original Keccak, RIPEMD160, MD5,
   and MACs based on AES and DES.
 - Random number generation. - Encodings and compression: base 64,
 hexadecimal, Zlib compression.

--- a/setup.ml
+++ b/setup.ml
@@ -6933,7 +6933,7 @@ let setup_t =
                  OASISText.Verbatim
                    " in ECB, CBC, CFB, OFB and counter modes.";
                  OASISText.Para
-                   "- Public-key cryptography: RSA encryption, Diffie-Hellman key agreement. - Hash functions and MACs: SHA-1, SHA-2, SHA-3, RIPEMD160, MD5,";
+                   "- Public-key cryptography: RSA encryption, Diffie-Hellman key agreement. - Hash functions and MACs: SHA-1, SHA-2, SHA-3, original Keccak, RIPEMD160, MD5,";
                  OASISText.Verbatim " and MACs based on AES and DES.";
                  OASISText.Para
                    "- Random number generation. - Encodings and compression: base 64, hexadecimal, Zlib compression.";

--- a/src/cryptokit.ml
+++ b/src/cryptokit.ml
@@ -70,8 +70,7 @@ external sha384_final: bytes -> string = "caml_sha384_final"
 type sha3_context
 external sha3_init: int -> sha3_context = "caml_sha3_init"
 external sha3_absorb: sha3_context -> bytes -> int -> int -> unit = "caml_sha3_absorb"
-external sha3_extract: sha3_context -> string = "caml_sha3_extract"
-external keccak_extract: sha3_context -> string = "caml_keccak_extract"
+external sha3_extract: bool -> sha3_context -> string = "caml_sha3_extract"
 external sha3_wipe: sha3_context -> unit = "caml_sha3_wipe"
 external ripemd160_init: unit -> bytes = "caml_ripemd160_init"
 external ripemd160_update: bytes -> bytes -> int -> int -> unit = "caml_ripemd160_update"
@@ -990,8 +989,7 @@ class sha3 sz official =
       self#add_string (String.make 1 c)
     method add_byte b =
       self#add_char (Char.unsafe_chr b)
-    method result =
-      (if official then sha3_extract else keccak_extract) context
+    method result = sha3_extract official context
     method wipe =
       sha3_wipe context
   end

--- a/src/cryptokit.mli
+++ b/src/cryptokit.mli
@@ -506,6 +506,10 @@ module Hash : sig
         produces hashes of 224, 256, 384 or 512 bits (24, 32, 48 or 64
         bytes).  The parameter is the desired size of the hash, in
         bits.  It must be one of 224, 256, 384 or 512. *)
+  val keccak: int -> hash
+    (** The Keccak submission for the SHA-3 is very similar to [sha3] but
+        uses a slightly different padding.  The parameter is the same as
+        that of [sha3]. *)
   val sha224: unit -> hash
     (** SHA-224 is SHA-2 specialized to 224 bit hashes (24 bytes). *)
   val sha256: unit -> hash

--- a/src/keccak.c
+++ b/src/keccak.c
@@ -153,14 +153,15 @@ void SHA3_absorb(struct SHA3Context * ctx,
   ctx->numbytes = len;
 }
 
-void SHA3_extract(struct SHA3Context * ctx,
+void SHA3_extract(unsigned char padding,
+                  struct SHA3Context * ctx,
                   unsigned char * output)
 {
   int i, j, n;
 
   /* Apply final padding */
   n = ctx->numbytes;
-  ctx->buffer[n] = 0x06;
+  ctx->buffer[n] = padding;
   n++;
   memset(ctx->buffer + n, 0, ctx->rsiz - n);
   ctx->buffer[ctx->rsiz - 1] |= 0x80;

--- a/src/keccak.h
+++ b/src/keccak.h
@@ -16,5 +16,6 @@ extern void SHA3_absorb(struct SHA3Context * ctx,
                         unsigned char * data,
                         unsigned long len);
 
-extern void SHA3_extract(struct SHA3Context * ctx,
+extern void SHA3_extract(unsigned char padding,
+                         struct SHA3Context * ctx,
                          unsigned char * output);

--- a/src/stubs-sha3.c
+++ b/src/stubs-sha3.c
@@ -60,21 +60,23 @@ CAMLprim value caml_sha3_absorb(value ctx,
 
 CAMLprim value caml_sha3_extract(value ctx)
 {
+  const unsigned sha3_padding = 0x06;
   CAMLparam1(ctx);
   CAMLlocal1(res);
 
   res = alloc_string(Context_val(ctx)->hsiz);
-  SHA3_extract(0x06, Context_val(ctx), &Byte_u(res, 0));
+  SHA3_extract(sha3_padding, Context_val(ctx), &Byte_u(res, 0));
   CAMLreturn(res);
 }
 
 CAMLprim value caml_keccak_extract(value ctx)
 {
+  const unsigned keccak_padding = 0x01;
   CAMLparam1(ctx);
   CAMLlocal1(res);
 
   res = alloc_string(Context_val(ctx)->hsiz);
-  SHA3_extract(1, Context_val(ctx), &Byte_u(res, 0));
+  SHA3_extract(keccak_padding, Context_val(ctx), &Byte_u(res, 0));
   CAMLreturn(res);
 }
 

--- a/src/stubs-sha3.c
+++ b/src/stubs-sha3.c
@@ -58,8 +58,15 @@ CAMLprim value caml_sha3_absorb(value ctx,
   return Val_unit;
 }
 
-static const unsigned sha3_padding = 0x06;
+
+/* On page 9 of Keccak Implementation Overview (Version 3.2)
+   http://keccak.noekeon.org/Keccak-implementation-3.2.pdf,
+   there is a figure `0x01` as the padding byte. */
 static const unsigned keccak_padding = 0x01;
+
+/* In a similar, updated description at http://keccak.noekeon.org/specs_summary.html,
+   on Table 3, `0x06` is shown as the relevant padding byte. */
+static const unsigned sha3_padding = 0x06;
 
 CAMLprim value caml_sha3_extract(value official, value ctx)
 {

--- a/src/stubs-sha3.c
+++ b/src/stubs-sha3.c
@@ -58,25 +58,16 @@ CAMLprim value caml_sha3_absorb(value ctx,
   return Val_unit;
 }
 
-CAMLprim value caml_sha3_extract(value ctx)
+static const unsigned sha3_padding = 0x06;
+static const unsigned keccak_padding = 0x01;
+
+CAMLprim value caml_sha3_extract(value official, value ctx)
 {
-  const unsigned sha3_padding = 0x06;
-  CAMLparam1(ctx);
+  CAMLparam2(official, ctx);
   CAMLlocal1(res);
 
   res = alloc_string(Context_val(ctx)->hsiz);
-  SHA3_extract(sha3_padding, Context_val(ctx), &Byte_u(res, 0));
-  CAMLreturn(res);
-}
-
-CAMLprim value caml_keccak_extract(value ctx)
-{
-  const unsigned keccak_padding = 0x01;
-  CAMLparam1(ctx);
-  CAMLlocal1(res);
-
-  res = alloc_string(Context_val(ctx)->hsiz);
-  SHA3_extract(keccak_padding, Context_val(ctx), &Byte_u(res, 0));
+  SHA3_extract(Bool_val(official) ? sha3_padding : keccak_padding, Context_val(ctx), &Byte_u(res, 0));
   CAMLreturn(res);
 }
 

--- a/src/stubs-sha3.c
+++ b/src/stubs-sha3.c
@@ -64,7 +64,17 @@ CAMLprim value caml_sha3_extract(value ctx)
   CAMLlocal1(res);
 
   res = alloc_string(Context_val(ctx)->hsiz);
-  SHA3_extract(Context_val(ctx), &Byte_u(res, 0));
+  SHA3_extract(0x06, Context_val(ctx), &Byte_u(res, 0));
+  CAMLreturn(res);
+}
+
+CAMLprim value caml_keccak_extract(value ctx)
+{
+  CAMLparam1(ctx);
+  CAMLlocal1(res);
+
+  res = alloc_string(Context_val(ctx)->hsiz);
+  SHA3_extract(1, Context_val(ctx), &Byte_u(res, 0));
   CAMLreturn(res);
 }
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -395,6 +395,61 @@ let _ =
   test 99 (hash_extremely_long (Hash.sha3 512))
     (hex "235ffd53504ef836 a1342b488f483b39 6eabbfe642cf78ee 0d31feec788b23d0 d18d5c339550dd59 58a500d4b95363da 1b5fa18affc1bab2 292dc63b7d85097c")
 
+(* Keccak *)
+let _ =
+  testing_function "Keccak";
+  let hash n s = hash_string (Hash.keccak n) s in
+  let s = "abc" in
+  test 1 (hash 224 s)
+    (hex "c30411768506ebe1 c2871b1ee2e87d38 df342317300a9b97 a95ec6a8");
+  test 2 (hash 256 s)
+    (hex "4e03657aea45a94f c7d47ba826c8d667 c0d1e6e33a64a036 ec44f58fa12d6c45");
+  test 3 (hash 384 s)
+    (hex "f7df1165f033337b e098e7d288ad6a2f 74409d7a60b49c36 642218de161b1f99 f8c681e4afaf31a3 4db29fb763e3c28e");
+  test 4 (hash 512 s)
+    (hex "18587dc2ea106b9a 1563e32b3312421c a164c7f1f07bc922 a9c83d77cea3a1e5 d0c6991073902537 2dc14ac964262937 9540c17e2a65b19d 77aa511a9d00bb96");
+  let s = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" in
+  test 5 (hash 224 s)
+    (hex "e51faa2b4655150b 931ee8d700dc202f 763ca5f962c529ea e55012b6");
+  test 6 (hash 256 s)
+    (hex "45d3b367a6904e6e 8d502ee04999a7c2 7647f91fa845d456 525fd352ae3d7371");
+  test 7 (hash 384 s)
+    (hex "b41e8896428f1bcb b51e17abd6acc980 52a3502e0d5bf7fa 1af949b4d3c855e7 c4dc2c390326b3f3 e74c7b1e2b9a3657");
+  test 8 (hash 512 s)
+    (hex "6aa6d3669597df6d 5a007b00d09c2079 5b5c4218234e1698 a944757a488ecdc0 9965435d97ca32c3 cfed7201ff30e070 cd947f1fc12b9d92 14c467d342bcba5d");
+  let s = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" in
+  test 9 (hash 224 s)
+    (hex "344298994b1b0687 3eae2ce739c425c4 7291a2e24189e01b 524f88dc");
+  test 10 (hash 256 s)
+    (hex "f519747ed599024f 3882238e5ab43960 132572b7345fbeb9 a90769dafd21ad67");
+  test 11 (hash 384 s)
+    (hex "cc063f3468513536 8b34f7449108f6d1 0fa727b09d696ec5 331771da46a923b6 c34dbd1d4f77e595 689c1f3800681c28");
+  test 12 (hash 512 s)
+    (hex "ac2fb35251825d3a a48468a9948c0a91 b8256f6d97d8fa41 60faff2dd9dfcc24 f3f1db7a983dad13 d53439ccac0b37e2 4037e7b95f80f59f 37a2f683c4ba4682");
+  test 13 (hash_million_a (Hash.keccak 224))
+    (hex "19f9167be2a04c43 abd0ed554788101b 9c339031acc8e146 8531303f");
+  test 14 (hash_million_a (Hash.keccak 256))
+    (hex "fadae6b49f129bbb 812be8407b7b2894 f34aecf6dbd1f9b0 f0c7e9853098fc96");
+  test 15 (hash_million_a (Hash.keccak 384))
+    (hex "0c8324e1ebc18282 2c5e2a086cac07c2 fe00e3bce61d01ba 8ad6b71780e2dec5 fb89e5ae90cb593e 57bc6258fdd94e17");
+  test 16 (hash_million_a (Hash.keccak 512))
+    (hex "5cf53f2e556be5a6 24425ede23d0e8b2 c7814b4ba0e4e09c bbf3c2fac7056f61 e048fc341262875e bc58a5183fea6514 47124370c1ebf4d6 c89bc9a7731063bb");
+  let s = "" in
+  test 17 (hash 224 s)
+    (hex "f71837502ba8e108 37bdd8d365adb855 91895602fc552b48 b7390abd");
+  test 18 (hash 256 s)
+    (hex "c5d2460186f7233c 927e7db2dcc703c0 e500b653ca82273b 7bfad8045d85a470");
+  test 19 (hash 384 s)
+    (hex "2c23146a63a29acf 99e73b88f8c24eaa 7dc60aa771780ccc 006afbfa8fe2479b 2dd2b21362337441 ac12b515911957ff");
+  test 20 (hash 512 s)
+    (hex "0eab42de4c3ceb92 35fc91acffe746b2 9c29a8c366b7c60e 4e67c466f36a4304 c00fa9caf9d87976 ba469bcbe06713b4 35f091ef2769fb16 0cdab33d3670680e");
+(*
+  test 98 (hash_extremely_long (Hash.keccak 256))
+         (hex "5f313c39963dcf79 2b5470d4ade9f3a3 56a3e4021748690a 958372e2b06f82a4");
+*)
+  test 99 (hash_extremely_long (Hash.keccak 512))
+         (hex "3e122edaf3739823 1cfaca4c7c216c9d 66d5b899ec1d7ac6 17c40c7261906a45 fc01617a021e5da3 bd8d4182695b5cb7 85a28237cbb16759 0e34718e56d8aab8")
+
 (* RIPEMD-160 *)
 let _ =
   testing_function "RIPEMD-160";

--- a/test/test.ml
+++ b/test/test.ml
@@ -396,6 +396,7 @@ let _ =
     (hex "235ffd53504ef836 a1342b488f483b39 6eabbfe642cf78ee 0d31feec788b23d0 d18d5c339550dd59 58a500d4b95363da 1b5fa18affc1bab2 292dc63b7d85097c")
 
 (* Keccak *)
+(* The test cases are taken from commit dec7e6dd8e5bbfe4534f7dd4c3fb4429575b23f8 *)
 let _ =
   testing_function "Keccak";
   let hash n s = hash_string (Hash.keccak n) s in

--- a/test/test.ml
+++ b/test/test.ml
@@ -443,10 +443,8 @@ let _ =
     (hex "2c23146a63a29acf 99e73b88f8c24eaa 7dc60aa771780ccc 006afbfa8fe2479b 2dd2b21362337441 ac12b515911957ff");
   test 20 (hash 512 s)
     (hex "0eab42de4c3ceb92 35fc91acffe746b2 9c29a8c366b7c60e 4e67c466f36a4304 c00fa9caf9d87976 ba469bcbe06713b4 35f091ef2769fb16 0cdab33d3670680e");
-(*
   test 98 (hash_extremely_long (Hash.keccak 256))
          (hex "5f313c39963dcf79 2b5470d4ade9f3a3 56a3e4021748690a 958372e2b06f82a4");
-*)
   test 99 (hash_extremely_long (Hash.keccak 512))
          (hex "3e122edaf3739823 1cfaca4c7c216c9d 66d5b899ec1d7ac6 17c40c7261906a45 fc01617a021e5da3 bd8d4182695b5cb7 85a28237cbb16759 0e34718e56d8aab8")
 


### PR DESCRIPTION
which uses a different padding character.
The tests are taken from revision 3d23e47db69200c2a736c109bb2093213d2d2323