### PR TITLE
add hmac_sha384 function

### DIFF
--- a/src/cryptokit.ml
+++ b/src/cryptokit.ml
@@ -1199,6 +1199,8 @@ module HMAC_SHA1 =
   HMAC(struct class h = Hash.sha1  let blocksize = 64 end)
 module HMAC_SHA256 =
   HMAC(struct class h = Hash.sha256  let blocksize = 64 end)
+module HMAC_SHA384 =
+  HMAC(struct class h = Hash.sha384  let blocksize = 128 end)
 module HMAC_SHA512 =
   HMAC(struct class h = Hash.sha512  let blocksize = 128 end)
 module HMAC_RIPEMD160 = 
@@ -1208,6 +1210,7 @@ module HMAC_MD5 =
 
 let hmac_sha1 key = new HMAC_SHA1.hmac key
 let hmac_sha256 key = new HMAC_SHA256.hmac key
+let hmac_sha384 key = new HMAC_SHA384.hmac key
 let hmac_sha512 key = new HMAC_SHA512.hmac key
 let hmac_ripemd160 key = new HMAC_RIPEMD160.hmac key
 let hmac_md5 key = new HMAC_MD5.hmac key

--- a/src/cryptokit.mli
+++ b/src/cryptokit.mli
@@ -649,6 +649,13 @@ module MAC: sig
         it can have any length, but a minimal length of 32 bytes is
         recommended. *)
 
+  val hmac_sha384: string -> hash
+    (** [hmac_sha384 key] returns a MAC based on the HMAC construction
+        (RFC2104) applied to SHA-384.  The returned hash values are
+        384 bits (48 bytes) long.  The [key] argument is the MAC key;
+        it can have any length, but a minimal length of 64 bytes is
+        recommended. *)
+
   val hmac_sha512: string -> hash
     (** [hmac_sha512 key] returns a MAC based on the HMAC construction
         (RFC2104) applied to SHA-512.  The returned hash values are

--- a/test/test.ml
+++ b/test/test.ml
@@ -633,6 +633,47 @@ let _ =
  "6355ac22e890d0a3c8481a5ca4825bc884d3e7a1ff98a2fc2ac7d8e064c3b2e6")
 ]
 
+(* HMAC-SHA384 *)
+
+let _ =
+  testing_function "HMAC-SHA384";
+  List.iter
+    (fun (testno, hexkey, hexmsg, hexhash) ->
+      test testno
+        (hash_string (MAC.hmac_sha384 (hex hexkey)) (hex hexmsg))
+        (hex hexhash))
+ [(1,
+   "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b\
+    0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b\
+    0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b\
+    0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+   "4869205468657265",
+   "51b2151ae771770f36cc6c5d63de41fc\
+    febab0900a22b41cb81e12209215337e\
+    5d5384201f6dc3ca9f92764c503380e6");
+  (2,
+   "4a6566654a6566654a6566654a656665\
+    4a6566654a6566654a6566654a656665\
+    4a6566654a6566654a6566654a656665\
+    4a6566654a6566654a6566654a656665",
+   "7768617420646f2079612077616e7420\
+    666f72206e6f7468696e673f",
+   "b57bd579eda34ac3f203e28660ed9992\
+    f7400d147af77a297b8a8a052e0d7eaa\
+    f54288f8a219dc55b49bb3147271f0b7");
+  (3,
+   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+   "dddddddddddddddddddddddddddddddd\
+    dddddddddddddddddddddddddddddddd\
+    dddddddddddddddddddddddddddddddd\
+    dddd",
+   "0b97cc8c49ef7ad3abd3e459c1084409\
+    a1778f0bd832e2126d25c93f7524b272\
+    a94f86587d874fefb80309910e70d958")]
+
 (* HMAC-SHA512 *)
 
 let _ =


### PR DESCRIPTION
Using the existing `HMAC` functor, apply the `Hash.sha384` class to
create a module and exposed function for creating HMAC hashes with the
SHA-384 algorithm.

The inputs for these tests were copied from the HMAC-SHA512 tests below
it. For each test, I made sure that I could produce the expected
HMAC-SHA512 output using `openssl sha512 -hmac` on the command line, and
then I switched `sha512` to `sha384`. The resulting output was used as
the expected value for each of the tests, and they all passed. This
makes me reasonably confident in its correctness.