### PR TITLE
Allow one to control whether the zlib transform expects a zlib header

### DIFF
--- a/src/cryptokit.ml
+++ b/src/cryptokit.ml
@@ -1891,9 +1891,9 @@ external inflate:
   = "caml_zlib_inflate_bytecode" "caml_zlib_inflate"
 external inflate_end: stream -> unit = "caml_zlib_inflateEnd"
 
-class compress level =
+class compress level write_zlib_header =
   object(self)
-    val zs = deflate_init level false
+    val zs = deflate_init level write_zlib_header
     
     inherit buffered_output 512 as output_buffer
 
@@ -1944,11 +1944,11 @@ class compress level =
       output_buffer#wipe
 end
 
-let compress ?(level = 6) () = new compress level
+let compress ?(level = 6) ?(write_zlib_header = false) () = new compress level write_zlib_header 
 
-class uncompress =
+class uncompress expect_zlib_header =
   object(self)
-    val zs = inflate_init false
+    val zs = inflate_init expect_zlib_header
     
     inherit buffered_output 512 as output_buffer
 
@@ -1997,7 +1997,7 @@ class uncompress =
       output_buffer#wipe
 end
 
-let uncompress () = new uncompress
+let uncompress ?(expect_zlib_header = false) () = new uncompress expect_zlib_header
 
 end
 

--- a/src/cryptokit.mli
+++ b/src/cryptokit.mli
@@ -1157,15 +1157,21 @@ end
     the size of the ciphertext. *)
 module Zlib: sig
 
-  val compress : ?level:int -> unit -> transform
+  val compress : ?level:int -> ?write_zlib_header:bool -> unit -> transform
     (** Return a transform that compresses its input.
         The optional [level] argument is an integer between 1 and 9
         specifying how hard the transform should try to compress data:
         1 is lowest but fastest compression, while 9 is highest but
-        slowest compression. The default level is 6. *)
+        slowest compression. The default level is 6.
+        The optional [write_zlib_header] argument dictates whether the 
+        output should be wrapped within a zlib header and checksum.
+        The default is false. *)
 
-  val uncompress : unit -> transform
-    (** Return a transform that decompresses its input. *)
+  val uncompress : ?expect_zlib_header:bool -> unit -> transform
+    (** Return a transform that decompresses its input.
+        The optional [expect_zlib_header] argument dictates whether the
+        input is wrapped within a zlib header and checksum. The default
+        is false. *)
 end
 
 (** {1 Error reporting} *)


### PR DESCRIPTION
This is already supported within stubs, the change simply exposes the option to the user.