### PR TITLE
Adds constant time equal functions for strings and bytes

### DIFF
--- a/src/cryptokit.ml
+++ b/src/cryptokit.ml
@@ -2024,3 +2024,21 @@ let mod_mult a b c =
   Bn.to_bytes ~numbits:(String.length c * 8)
     (Bn.mod_ (Bn.mult (Bn.of_bytes a) (Bn.of_bytes b))
              (Bn.of_bytes c))
+
+let const_time_eq eq len a b =
+  if len a = len b
+  then
+    let l = len a in
+    let lst = List.init l (fun x -> x) in
+    let fold acc i =
+      acc && (eq a b i) in
+    List.fold_left fold true lst
+  else false
+
+let const_time_eq_str = const_time_eq (fun a b i ->
+    String.get a i = String.get b i) String.length
+
+
+let const_time_eq_bytes = const_time_eq (fun a b i ->
+    Bytes.get a i = Bytes.get b i) Bytes.length
+

--- a/src/cryptokit.mli
+++ b/src/cryptokit.mli
@@ -1249,3 +1249,12 @@ val mod_mult: string -> string -> string -> string
     (** [mod_mult a b c] computes [a*b mod c], where the
         strings [a], [b], [c] and the result are viewed as
         arbitrary-precision integers in big-endian format. *)
+
+val const_time_eq_str : string -> string -> bool
+    (** [const_time_eq_str a b] compares the two strings [a] and  [b]
+        in constant time *)
+
+val const_time_eq_bytes : bytes -> bytes -> bool
+    (** [const_time_eq_bytes a b] compares the two byte strings [a] and [b]
+        in constant time *)
+

--- a/test/test.ml
+++ b/test/test.ml
@@ -945,6 +945,25 @@ let _ =
   end
 
 
+let _ =
+  testing_function "Constant time equal";
+  test 1 (const_time_eq_str "abc" "ab") false;
+
+  test 2 (const_time_eq_bytes (Bytes.of_string "abc") (Bytes.of_string "ab")) false;
+
+  test 3 (const_time_eq_str "coolcoolcool" "coolcoolnice") false;
+  
+  test 4 (const_time_eq_bytes
+            (Bytes.of_string "coolcoolcool")
+            (Bytes.of_string "coolcoolnice")) false;
+
+  test 5 (const_time_eq_str "coolcoolcool" "coolcoolcool") true;
+
+  test 6 (const_time_eq_bytes
+            (Bytes.of_string "coolcoolcool")
+            (Bytes.of_string "coolcoolcool")) true
+;;
+  
 (* End of tests *)
 
 let _ =
@@ -956,4 +975,3 @@ let _ =
     printf "All tests successful.\n";
     exit 0
   end
-


### PR DESCRIPTION
Hoping to help with #13 to avoid timing attacks on hashes and other comparisions.
I'm not sure how to write tests to make sure the functions are constant time, but I'm pretty sure they are, please review, tho.