### PR TITLE
DH.new_parameters

### DIFF
--- a/src/cryptokit.mli
+++ b/src/cryptokit.mli
@@ -861,7 +861,7 @@ module DH: sig
     (** Generate a new set of Diffie-Hellman parameters.
       The non-optional argument is the size in bits of the [p] parameter.
       It must be large enough that the discrete logarithm problem modulo
-      [p] is computationally unsolvable.  1024 is a reasonable value.
+      [p] is computationally unsolvable.  2048 is a reasonable value.
       The optional [rng] argument specifies a random number generator
       to use for generating the parameters; it defaults to
       {!Cryptokit.Random.secure_rng}.  The optional [privlen] argument


### PR DESCRIPTION
Update documentation to reflect state of the art.

According to a work (with some INRIA authors):

https://weakdh.org/imperfect-forward-secrecy-ccs15.pdf

```
@inproceedings{weakdh15,
     title = {Imperfect Forward Secrecy: {H}ow {D}iffie-{H}ellman Fails
                  in Practice},
     author = {David Adrian and Karthikeyan Bhargavan and Zakir Durumeric
                  and Pierrick Gaudry and Matthew Green and J. Alex
                  Halderman and Nadia Heninger and Drew Springall and
                  Emmanuel Thom\'e and Luke Valenta and Benjamin
                  VanderSloot and Eric Wustrow and Santiago
                  Zanella-B\'eguelin and Paul Zimmermann},
     booktitle = {22nd ACM Conference on Computer and Communications
                  Security},
     month = oct,
     year = 2015
     }
```

2048, instead of 1024, is a reasonable value.