### PR TITLE
raise_not_found <- caml_raise_not_found

### DIFF
--- a/src/stubs-rng.c
+++ b/src/stubs-rng.c
@@ -43,7 +43,7 @@ CAMLprim value caml_get_system_rng(value unit)
 
   if (! CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL,
                             CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
-    raise_not_found();
+    caml_raise_not_found();
   res = caml_alloc((sizeof(HCRYPTPROV) + sizeof(value) - 1) / sizeof(value),
               Abstract_tag);
   HCRYPTPROV_val(res) = prov;


### PR DESCRIPTION
Désolé de ne pas avoir vu également celui-là la dernière fois (f9b80b2f02dc94be75856824b5e4b9717992761e) : maintenant, ça compile bien sous windows (ocaml-variants.4.12.0+mingw64c) et les tests passent.

Cordialement