### PR TITLE
Re-expose CryptokitBignum module

### DIFF
--- a/src/cryptokit.ml
+++ b/src/cryptokit.ml
@@ -154,7 +154,7 @@ let transform_channel tr ?len ic oc =
   tr#finish;
   let (obuf, opos, olen) = tr#get_substring in
   output oc obuf opos olen;
-  tr#wipe  
+  tr#wipe
 
 class compose (tr1 : transform) (tr2 : transform) =
   object(self)
@@ -328,7 +328,7 @@ class buffered_output initial_buffer_size =
       r
 
     method get_byte =
-      Char.code self#get_char          
+      Char.code self#get_char
 
     method wipe =
       wipe_bytes obuf
@@ -1258,7 +1258,7 @@ module HMAC_SHA256 =
   HMAC(struct class h = Hash.sha256  let blocksize = 64 end)
 module HMAC_SHA512 =
   HMAC(struct class h = Hash.sha512  let blocksize = 128 end)
-module HMAC_RIPEMD160 = 
+module HMAC_RIPEMD160 =
   HMAC(struct class h = Hash.ripemd160  let blocksize = 64 end)
 module HMAC_MD5 =
   HMAC(struct class h = Hash.md5  let blocksize = 64 end)
@@ -1327,7 +1327,7 @@ let string rng len =
 type system_rng_handle
 external get_system_rng: unit -> system_rng_handle = "caml_get_system_rng"
 external close_system_rng: system_rng_handle -> unit = "caml_close_system_rng"
-external system_rng_random_bytes: 
+external system_rng_random_bytes:
   system_rng_handle -> bytes -> int -> int -> bool
   = "caml_system_rng_random_bytes"
 
@@ -1351,7 +1351,7 @@ class device_rng filename =
   object(self)
     val fd = Unix.openfile filename [Unix.O_RDONLY; Unix.O_CLOEXEC] 0
     method random_bytes buf ofs len =
-      if len > 0 then begin    
+      if len > 0 then begin
         let n = Unix.read fd buf ofs len in
         if n = 0 then raise(Error Entropy_source_closed);
         if n < len then self#random_bytes buf (ofs + n) (len - n)
@@ -1371,7 +1371,7 @@ class egd_rng socketname =
       with exn ->
         Unix.close s; raise exn
     method random_bytes buf ofs len =
-      if len > 0 then begin    
+      if len > 0 then begin
         let reqd = min 255 len in
         let msg = Bytes.create 2 in
         Bytes.set msg 0 '\002'; (* read entropy blocking *)
@@ -1398,7 +1398,7 @@ external hardware_rng_random_bytes: bytes -> int -> int -> bool = "caml_hardware
 class hardware_rng =
   object
     method random_bytes buf ofs len =
-      if ofs < 0 || len < 0 || ofs > Bytes.length buf - len      
+      if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
       then invalid_arg "hardware_rng#random_bytes";
       if not (hardware_rng_random_bytes buf ofs len)
       then raise (Error Entropy_source_closed)
@@ -1413,7 +1413,7 @@ let hardware_rng () =
 
 class no_rng =
   object
-    method random_bytes (buf:bytes) (ofs:int) (len:int) : unit = 
+    method random_bytes (buf:bytes) (ofs:int) (len:int) : unit =
       raise (Error No_entropy_source)
     method wipe = ()
   end
@@ -1447,7 +1447,7 @@ class pseudo_rng seed =
   object (self)
     val ckey =
       let l = String.length seed in
-      chacha20_cook_key 
+      chacha20_cook_key
         (if l >= 32 then String.sub seed 0 32
          else if l > 16 then seed ^ String.make (32 - l) '\000'
          else seed)
@@ -1496,6 +1496,7 @@ end
 
 (* RSA operations *)
 
+module CryptokitBignum = CryptokitBignum
 module Bn = CryptokitBignum
 
 module RSA = struct
@@ -1666,7 +1667,7 @@ let derive_key ?(diversification = "") sharedsec numbytes =
   let rec derive pos counter =
     if pos < numbytes then begin
       let h =
-        hash_string (Hash.sha256()) 
+        hash_string (Hash.sha256())
                     (diversification ^ sharedsec ^ string_of_int counter) in
       String.blit h 0 result pos (min (String.length h) (numbytes - pos));
       wipe_string h;
@@ -1715,7 +1716,7 @@ class encode multiline padding =
           Bytes.set obuf oend '\n';
           oend <- oend + 1;
           ocolumn <- 0
-        end 
+        end
       end
 
     method put_substring s ofs len =
@@ -1957,7 +1958,7 @@ external inflate_end: stream -> unit = "caml_zlib_inflateEnd"
 class compress level write_zlib_header =
   object(self)
     val zs = deflate_init level write_zlib_header
-    
+
     inherit buffered_output 512 as output_buffer
 
     method input_block_size = 1
@@ -2007,12 +2008,12 @@ class compress level write_zlib_header =
       output_buffer#wipe
 end
 
-let compress ?(level = 6) ?(write_zlib_header = false) () = new compress level write_zlib_header 
+let compress ?(level = 6) ?(write_zlib_header = false) () = new compress level write_zlib_header
 
 class uncompress expect_zlib_header =
   object(self)
     val zs = inflate_init expect_zlib_header
-    
+
     inherit buffered_output 512 as output_buffer
 
     method input_block_size = 1
@@ -2085,14 +2086,14 @@ let xor_bytes src src_ofs dst dst_ofs len =
   || dst_ofs < 0 || dst_ofs > Bytes.length dst - len
   then invalid_arg "xor_bytes";
   xor_bytes src src_ofs dst dst_ofs len
-  
+
 let xor_string src src_ofs dst dst_ofs len =
   if len < 0
   || src_ofs < 0 || src_ofs > String.length src - len
   || dst_ofs < 0 || dst_ofs > Bytes.length dst - len
   then invalid_arg "xor_string";
   xor_string src src_ofs dst dst_ofs len
-  
+
 let mod_power a b c =
   Bn.to_bytes ~numbits:(String.length c * 8)
     (Bn.mod_power (Bn.of_bytes a) (Bn.of_bytes b) (Bn.of_bytes c))

--- a/src/cryptokit.mli
+++ b/src/cryptokit.mli
@@ -69,7 +69,7 @@ class type transform =
     method flush: unit
       (** [flush] causes the transform to flush its internal buffers
           and make all output processed up to this point available through
-          the [get_*] methods.  
+          the [get_*] methods.
           Raise [Error Wrong_data_length] if the total length
           of input data provided via the [put_*] methods is not
           an integral number of the input block size
@@ -159,7 +159,7 @@ val transform_channel:
       is provided, exactly [len] characters are read from [ic] and
       transformed; [End_of_file] is raised if [ic] does not contain
       at least [len] characters.  If [len] is not provided, [ic] is
-      read all the way to end of file. 
+      read all the way to end of file.
       The transform [t] is wiped before returning, hence can
       no longer be used for further transformations. *)
 
@@ -208,7 +208,7 @@ class type hash =
 
 val hash_string: hash -> string -> string
   (** [hash_string h s] runs the string [s] through the hash function [h]
-      and returns the hash value of [s].  
+      and returns the hash value of [s].
       The hash [h] is wiped before returning, hence can
       no longer be used for further hash computations. *)
 
@@ -218,7 +218,7 @@ val hash_channel: hash -> ?len:int -> in_channel -> string
       If the optional [len] argument is provided, exactly [len] characters
       are read from [ic] and hashed; [End_of_file] is raised if [ic]
       does not contain at least [len] characters.
-      If [len] is not provided, [ic] is read all the way to end of file.      
+      If [len] is not provided, [ic] is read all the way to end of file.
       The hash [h] is wiped before returning, hence can
       no longer be used for further hash computations. *)
 
@@ -315,7 +315,7 @@ module Random : sig
         pseudo-random data is the result of encrypting the 128-bit integers
         [0, 1, 2, ...] with this key. *)
 
-end        
+end
 
 (** The [Padding] module defines a generic interface
     for padding input data to an integral number of blocks,
@@ -444,7 +444,7 @@ module Cipher : sig
         reused.
 
         The string argument is the key; its length must be either 16
-        or (better) 32.  
+        or (better) 32.
 
         The optional [iv] argument is the initialization vector (also
         called nonce) that can be used to diversify the key.  If present,
@@ -760,6 +760,8 @@ module MAC: sig
         the final MAC. *)
 end
 
+module CryptokitBignum = CryptokitBignum
+
 (** The [RSA] module implements RSA public-key cryptography.
     Public-key cryptography is asymmetric: two distinct keys are used
     for encrypting a message, then decrypting it.  Moreover, while one of
@@ -863,7 +865,7 @@ end
   by exchanging messages, with the guarantee that even if an attacker
   eavesdrop on the messages, he cannot recover the shared secret.
   Diffie-Hellman is one such key agreement protocol, relying on
-  the difficulty of computing discrete logarithms.  Notice that 
+  the difficulty of computing discrete logarithms.  Notice that
   the Diffie-Hellman protocol is vulnerable to active attacks
   (man-in-the-middle attacks).
 
@@ -910,7 +912,7 @@ module DH: sig
     (** The abstract type of private secrets generated during key agreement. *)
 
   val private_secret: ?rng: Random.rng -> parameters -> private_secret
-    (** Generate a random private secret.  
+    (** Generate a random private secret.
       The optional [rng] argument specifies a random number generator
       to use; it defaults to {!Cryptokit.Random.secure_rng}. *)
 
@@ -938,7 +940,7 @@ module DH: sig
       counter until [numbytes] bytes have been obtained. *)
 end
 
-(** {1 Advanced, compositional interface to block ciphers 
+(** {1 Advanced, compositional interface to block ciphers
        and stream ciphers} *)
 
 (** The [Block] module provides classes that implements
@@ -1055,7 +1057,7 @@ module Block : sig
 
   class cbc_decrypt: ?iv: string -> block_cipher -> block_cipher
     (** Add Cipher Block Chaining (CBC) to the given block cipher
-        in decryption mode.  This works like {!Cryptokit.Block.cbc_encrypt}, 
+        in decryption mode.  This works like {!Cryptokit.Block.cbc_encrypt},
         except that input blocks are first decrypted by the block
         cipher before being xor-ed with the previous input block. *)
 
@@ -1074,7 +1076,7 @@ module Block : sig
     (** Add Output Feedback Block (OFB) to the given block cipher.
         The integer argument [n] is the number of
         bytes processed at a time; it must lie between [1] and
-        the block size of the underlying cipher, included.        
+        the block size of the underlying cipher, included.
         The returned block cipher has block size [n].
         It is usable both for encryption and decryption. *)
 
@@ -1149,7 +1151,7 @@ module Base64: sig
     (** Return a transform that performs base 64 encoding.
         The output is divided in lines of length 76 characters,
         and final [=] characters are used to pad the output,
-        as specified in the MIME standard. 
+        as specified in the MIME standard.
         The output is approximately [4/3] longer than the input. *)
 
   val encode_compact : unit -> transform
@@ -1201,7 +1203,7 @@ module Zlib: sig
         specifying how hard the transform should try to compress data:
         1 is lowest but fastest compression, while 9 is highest but
         slowest compression. The default level is 6.
-        The optional [write_zlib_header] argument dictates whether the 
+        The optional [write_zlib_header] argument dictates whether the
         output should be wrapped within a zlib header and checksum.
         The default is false. *)
 
@@ -1290,7 +1292,7 @@ val xor_bytes: bytes -> int -> bytes -> int -> int -> unit
         storing the result in [dst] starting at position [dpos]. *)
 
 val xor_string: string -> int -> bytes -> int -> int -> unit
-    (** Same as [xor_bytes], but the source is a string instead of a 
+    (** Same as [xor_bytes], but the source is a string instead of a
         byte array. *)
 
 val mod_power: string -> string -> string -> string


### PR DESCRIPTION
The `CryptokitBignum` module stopped being exposed after cryptokit was updated to build with dune. This breaks users that were depending on it, and requires pinning to cryptokit <v1.16.

Assuming that this module was not intentionally removed from the interface of the library, please kindly consider merging this PR.