### PR TITLE
fix some linking errors caused by collisions with openssl 

### DIFF
--- a/src/keccak.c
+++ b/src/keccak.c
@@ -114,7 +114,7 @@ static void KeccakAbsorb(u64 st[25], unsigned char * p, int rsiz)
 
 /* Exported interface */
 
-void SHA3_init(struct SHA3Context * ctx, int hsiz)
+void cryptokit_SHA3_init(struct SHA3Context * ctx, int hsiz)
 {
   assert (hsiz == 224 || hsiz == 256 || hsiz == 384 || hsiz == 512);
   ctx->hsiz = hsiz / 8;
@@ -123,7 +123,7 @@ void SHA3_init(struct SHA3Context * ctx, int hsiz)
   memset(ctx->state, 0, sizeof(ctx->state));
 }
 
-void SHA3_absorb(struct SHA3Context * ctx, 
+void cryptokit_SHA3_absorb(struct SHA3Context * ctx, 
                  unsigned char * data,
                  unsigned long len)
 {
@@ -153,7 +153,7 @@ void SHA3_absorb(struct SHA3Context * ctx,
   ctx->numbytes = len;
 }
 
-void SHA3_extract(unsigned char padding,
+void cryptokit_SHA3_extract(unsigned char padding,
                   struct SHA3Context * ctx,
                   unsigned char * output)
 {

--- a/src/keccak.h
+++ b/src/keccak.h
@@ -10,12 +10,12 @@ struct SHA3Context {
   int hsiz;           /* size of hash in bytes */
 };
 
-extern void SHA3_init(struct SHA3Context * ctx, int hsiz);
+extern void cryptokit_SHA3_init(struct SHA3Context * ctx, int hsiz);
 
-extern void SHA3_absorb(struct SHA3Context * ctx, 
+extern void cryptokit_SHA3_absorb(struct SHA3Context * ctx, 
                         unsigned char * data,
                         unsigned long len);
 
-extern void SHA3_extract(unsigned char padding,
+extern void cryptokit_SHA3_extract(unsigned char padding,
                          struct SHA3Context * ctx,
                          unsigned char * output);

--- a/src/poly1305-donna-32.h
+++ b/src/poly1305-donna-32.h
@@ -41,7 +41,7 @@ U32TO8(unsigned char *p, uint32_t v) {
 }
 
 void
-poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+cryptokit_poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 
 	/* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
@@ -130,7 +130,7 @@ poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t by
 }
 
 void
-poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
+cryptokit_poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	uint32_t h0,h1,h2,h3,h4,c;
 	uint32_t g0,g1,g2,g3,g4;

--- a/src/poly1305-donna-64.h
+++ b/src/poly1305-donna-64.h
@@ -60,7 +60,7 @@ U64TO8(unsigned char *p, uint64_t v) {
 }
 
 void
-poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+cryptokit_poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	uint64_t t0,t1;
 
@@ -139,7 +139,7 @@ poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t by
 
 
 void
-poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
+cryptokit_poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	uint64_t h0,h1,h2,c;
 	uint64_t g0,g1,g2;

--- a/src/poly1305-donna.c
+++ b/src/poly1305-donna.c
@@ -13,7 +13,7 @@
 #endif
 
 void
-poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes) {
+cryptokit_poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	size_t i;
 

--- a/src/poly1305-donna.h
+++ b/src/poly1305-donna.h
@@ -13,9 +13,9 @@ typedef struct poly1305_context {
 	unsigned char opaque[136];
 } poly1305_context;
 
-void poly1305_init(poly1305_context *ctx, const unsigned char key[32]);
-void poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes);
-void poly1305_finish(poly1305_context *ctx, unsigned char mac[16]);
+void cryptokit_poly1305_init(poly1305_context *ctx, const unsigned char key[32]);
+void cryptokit_poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes);
+void cryptokit_poly1305_finish(poly1305_context *ctx, unsigned char mac[16]);
 
 #endif /* POLY1305_DONNA_H */
 

--- a/src/stubs-poly1305.c
+++ b/src/stubs-poly1305.c
@@ -22,13 +22,13 @@ CAMLprim value caml_poly1305_init(value key)
 {
   CAMLparam1(key);
   value ctx = caml_alloc_string(sizeof(struct poly1305_context));
-  poly1305_init(Context_val(ctx), &Byte_u(key, 0));
+  cryptokit_poly1305_init(Context_val(ctx), &Byte_u(key, 0));
   CAMLreturn(ctx);
 }
 
 CAMLprim value caml_poly1305_update(value ctx, value src, value ofs, value len)
 {
-  poly1305_update(Context_val(ctx), &Byte_u(src, Long_val(ofs)), Long_val(len));
+  cryptokit_poly1305_update(Context_val(ctx), &Byte_u(src, Long_val(ofs)), Long_val(len));
   return Val_unit;
 }
 
@@ -37,7 +37,7 @@ CAMLprim value caml_poly1305_final(value ctx)
   CAMLparam1(ctx);
   CAMLlocal1(res);
   res = caml_alloc_string(16);
-  poly1305_finish(Context_val(ctx), &Byte_u(res, 0));
+  cryptokit_poly1305_finish(Context_val(ctx), &Byte_u(res, 0));
   CAMLreturn(res);
 }
 

--- a/src/stubs-sha3.c
+++ b/src/stubs-sha3.c
@@ -46,7 +46,7 @@ CAMLprim value caml_sha3_init(value vsize)
     caml_alloc_custom(&SHA3_context_ops,
                       sizeof(struct SHA3Context *),
                       0, 1);
-  SHA3_init(ctx, Int_val(vsize));
+  cryptokit_SHA3_init(ctx, Int_val(vsize));
   Context_val(res) = ctx;
   return res;
 }
@@ -54,7 +54,7 @@ CAMLprim value caml_sha3_init(value vsize)
 CAMLprim value caml_sha3_absorb(value ctx,
                                 value src, value ofs, value len)
 {
-  SHA3_absorb(Context_val(ctx), &Byte_u(src, Long_val(ofs)), Long_val(len));
+  cryptokit_SHA3_absorb(Context_val(ctx), &Byte_u(src, Long_val(ofs)), Long_val(len));
   return Val_unit;
 }
 
@@ -74,7 +74,7 @@ CAMLprim value caml_sha3_extract(value official, value ctx)
   CAMLlocal1(res);
 
   res = caml_alloc_string(Context_val(ctx)->hsiz);
-  SHA3_extract(Bool_val(official) ? sha3_padding : keccak_padding, Context_val(ctx), &Byte_u(res, 0));
+  cryptokit_SHA3_extract(Bool_val(official) ? sha3_padding : keccak_padding, Context_val(ctx), &Byte_u(res, 0));
   CAMLreturn(res);
 }
 


### PR DESCRIPTION
on alpine, trying to do a static build with cryptokit and openssl (pulled in by another library), I met some symbol collisions that could only be fixed by prefixing C functions. For uniformity I renamed all the public C functions for sha3 and poly1305-donna so they start with `cryptokit_`.
