### PR TITLE
RSA: use different types for private and public keys

### DIFF
--- a/src/cryptokit.ml
+++ b/src/cryptokit.ml
@@ -1946,20 +1946,25 @@ module Bn = CryptokitBignum
 
 module RSA = struct
 
-type key =
+type public_key =
   { size: int;
     n: string;
-    e: string;
+    e: string
+  }
+
+type private_key =
+  { size: int;
+    n: string;
     d: string;
     p: string;
     q: string;
     dp: string;
     dq: string;
-    qinv: string }
+    qinv: string
+  }
 
-let wipe_key k =
+let wipe_key (k: private_key) =
   wipe_string k.n;
-  wipe_string k.e;
   wipe_string k.d;
   wipe_string k.p;
   wipe_string k.q;
@@ -1967,7 +1972,7 @@ let wipe_key k =
   wipe_string k.dq;
   wipe_string k.qinv
 
-let encrypt key msg =
+let encrypt (key: public_key) msg =
   let msg = Bn.of_bytes msg in
   let n = Bn.of_bytes key.n in
   let e = Bn.of_bytes key.e in
@@ -1979,7 +1984,7 @@ let encrypt key msg =
 
 let unwrap_signature = encrypt
 
-let decrypt key msg =
+let decrypt (key: private_key) msg =
   let msg = Bn.of_bytes msg in
   let n = Bn.of_bytes key.n in
   let d = Bn.of_bytes key.d in
@@ -1991,7 +1996,7 @@ let decrypt key msg =
 
 let sign = decrypt
 
-let decrypt_CRT key msg =
+let decrypt_CRT (key: private_key) msg =
   let msg = Bn.of_bytes msg in
   let n = Bn.of_bytes key.n in
   let p = Bn.of_bytes key.p in
@@ -2054,21 +2059,24 @@ let new_key ?(rng = Random.secure_rng) ?e numbits =
   (* qinv = q^-1 mod p *)
   let qinv = Bn.mod_inv q p in
   (* Build key *)
-  let res =
+  let priv : private_key =
     { size = numbits;
       n = Bn.to_bytes ~numbits:numbits n;
-      e = Bn.to_bytes ~numbits:numbits e;
       d = Bn.to_bytes ~numbits:numbits d;
       p = Bn.to_bytes ~numbits:numbits2 p;
       q = Bn.to_bytes ~numbits:numbits2 q;
       dp = Bn.to_bytes ~numbits:numbits2 dp;
       dq = Bn.to_bytes ~numbits:numbits2 dq;
-      qinv = Bn.to_bytes ~numbits:numbits2 qinv } in
+      qinv = Bn.to_bytes ~numbits:numbits2 qinv }
+  and pub : public_key =
+    { size = numbits;
+      n = Bn.to_bytes ~numbits:numbits n;
+      e = Bn.to_bytes ~numbits:numbits e } in
   Bn.wipe n; Bn.wipe e; Bn.wipe d;
   Bn.wipe p; Bn.wipe q;
   Bn.wipe p1; Bn.wipe q1;
   Bn.wipe dp; Bn.wipe dq; Bn.wipe qinv;
-  res
+  (priv, pub)
 
 end
 

--- a/test/speedtest.ml
+++ b/test/speedtest.ml
@@ -135,17 +135,17 @@ let _ =
   time_fn "SipHash 128, 64_000_000 bytes, 16-byte chunks"
     (hash (MAC.siphash128 "0123456789ABCDEF") 4000000 16);
   let prng = Random.pseudo_rng "supercalifragilistusexpialidolcius" in
-  let key =
+  let (priv_key, pub_key) =
   time_fn "RSA key generation (2048 bits) x 10"
     (repeat 10 (fun () -> RSA.new_key ~rng:prng ~e:65537 2048)) in
   let plaintext = "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" in
   let ciphertext =
   time_fn "RSA public-key operation (2048 bits, exponent 65537) x 1000"
-    (repeat 1000 (fun () -> RSA.encrypt key plaintext)) in
+    (repeat 1000 (fun () -> RSA.encrypt pub_key plaintext)) in
   time_fn "RSA private-key operation (2048 bits) x 100"
-    (repeat 100 (fun () -> ignore(RSA.decrypt key ciphertext)));
+    (repeat 100 (fun () -> ignore(RSA.decrypt priv_key ciphertext)));
   time_fn "RSA private-key operation with CRT (2048 bits) x 100"
-    (repeat 100 (fun () -> ignore(RSA.decrypt_CRT key ciphertext)));
+    (repeat 100 (fun () -> ignore(RSA.decrypt_CRT priv_key ciphertext)));
   time_fn "PRNG, 64_000_000 bytes"
     (rng prng 1000000 64);
   time_fn "PRNG AES CTR, 64_000_000 bytes"

--- a/test/test.ml
+++ b/test/test.ml
@@ -1282,16 +1282,20 @@ let _ =
 
 (* RSA *)
 
-let some_rsa_key = {
+let some_private_key : RSA.private_key = {
   RSA.size = 512;
   RSA.n = hex "c0764797b8bec8972a0ed8c90a8c334dd049add0222c09d20be0a79e338910bcae422060906ae0221de3f3fc747ccf98aecc85d6edc52d93d5b7396776160525";
-  RSA.e = hex "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010001";
   RSA.d = hex "1ae36b7522f66487d9f4610d1550290ac202c929bedc7032cc3e02acf37e3ebc1f866ee7ef7a0868d23ae2b184c1abd6d4db8ea9bec046bd82803727f2888701";
   RSA.p = hex "df02b615fe15928f41b02b586b51c2c02260ca396818ca4cba60bb892465be35";
   RSA.q = hex "dceeb60d543518b4ac74834a0546c507f2e91e389a87e2f2becc6f8c67d1c931";
   RSA.dp = hex "59487e99e375c38d732112d97d6de8687fdafc5b6b5fb16e7297d3bd1e435599";
   RSA.dq = hex "61b550de6437774db0577718ed6c770724eee466b43114b5b69c43591d313281";
   RSA.qinv = hex "744c79c4b9bea97c25e563c9407a2d09b57358afe09af67d71f8198cb7c956b8"
+}
+let some_public_key : RSA.public_key = {
+  RSA.size = 512;
+  RSA.n = hex "c0764797b8bec8972a0ed8c90a8c334dd049add0222c09d20be0a79e338910bcae422060906ae0221de3f3fc747ccf98aecc85d6edc52d93d5b7396776160525";
+  RSA.e = hex "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010001"
 }
 
 let some_msg = "Supercalifragilistusexpialidolcius"
@@ -1304,38 +1308,38 @@ let _ =
   testing_function "RSA";
   (* Signature, no CRT *)
   test_same_message 1 some_msg 
-    (RSA.unwrap_signature some_rsa_key (RSA.sign some_rsa_key some_msg));
+    (RSA.unwrap_signature some_public_key (RSA.sign some_private_key some_msg));
   (* Signature, CRT *)
   test_same_message 2 some_msg
-    (RSA.unwrap_signature some_rsa_key (RSA.sign_CRT some_rsa_key some_msg));
+    (RSA.unwrap_signature some_public_key (RSA.sign_CRT some_private_key some_msg));
   (* Encryption, no CRT *)
   test_same_message 3 some_msg
-    (RSA.decrypt some_rsa_key (RSA.encrypt some_rsa_key some_msg));
+    (RSA.decrypt some_private_key (RSA.encrypt some_public_key some_msg));
   (* Encryption, CRT *)
   test_same_message 4 some_msg
-    (RSA.decrypt_CRT some_rsa_key (RSA.encrypt some_rsa_key some_msg));
+    (RSA.decrypt_CRT some_private_key (RSA.encrypt some_public_key some_msg));
   (* Same, with a home-made key *)
   let prng =
     Random.pseudo_rng (hex "5b5e50dc5b6eaf5346eba8244e5666ac4dcd5409") in
-  let key = RSA.new_key ~rng:prng 1024 in
+  let (priv_key, pub_key) = RSA.new_key ~rng:prng 1024 in
   test_same_message 5 some_msg
-    (RSA.unwrap_signature key (RSA.sign key some_msg));
+    (RSA.unwrap_signature pub_key (RSA.sign priv_key some_msg));
   test_same_message 6 some_msg
-    (RSA.unwrap_signature key (RSA.sign_CRT key some_msg));
+    (RSA.unwrap_signature pub_key (RSA.sign_CRT priv_key some_msg));
   test_same_message 7 some_msg
-    (RSA.decrypt key (RSA.encrypt key some_msg));
+    (RSA.decrypt priv_key (RSA.encrypt pub_key some_msg));
   test_same_message 8 some_msg
-    (RSA.decrypt_CRT key (RSA.encrypt key some_msg));
+    (RSA.decrypt_CRT priv_key (RSA.encrypt pub_key some_msg));
   (* Same, with a home-made key of fixed public exponent *)
-  let key = RSA.new_key ~rng:prng ~e:65537 1024 in
+  let (priv_key, pub_key) = RSA.new_key ~rng:prng ~e:65537 1024 in
   test_same_message 9 some_msg
-    (RSA.unwrap_signature key (RSA.sign key some_msg));
+    (RSA.unwrap_signature pub_key (RSA.sign priv_key some_msg));
   test_same_message 10 some_msg
-    (RSA.unwrap_signature key (RSA.sign_CRT key some_msg));
+    (RSA.unwrap_signature pub_key (RSA.sign_CRT priv_key some_msg));
   test_same_message 11 some_msg
-    (RSA.decrypt key (RSA.encrypt key some_msg));
+    (RSA.decrypt priv_key (RSA.encrypt pub_key some_msg));
   test_same_message 12 some_msg
-    (RSA.decrypt_CRT key (RSA.encrypt key some_msg))
+    (RSA.decrypt_CRT priv_key (RSA.encrypt pub_key some_msg))
 
 (* Diffie-Hellman *)
 


### PR DESCRIPTION
This makes the API clearer and more robust against programming errors.  It does break the few existing uses of Cryptokit.RSA, however.

I cannot remember the reason why it was not done this way initially.  Perhaps because at the time OCaml did not support type-based disambiguation of record labels, making it nearly impossible to have the same `n` label in two record types.
